### PR TITLE
Add new package: DevKen.YoloPredictor.OpenCvBridge

### DIFF
--- a/.github/workflows/NugetPublish.yml
+++ b/.github/workflows/NugetPublish.yml
@@ -52,3 +52,15 @@ jobs:
         PACKAGE_NAME: DevKen.YoloPredictor.Yolov5
         # API key to authenticate with NuGet server
         NUGET_KEY: ${{secrets.NUGET_API_KEY}}
+        
+    - name: Publish NuGet YoloPredictor.OpenCvBridge
+      # You may pin to the exact commit or the version.
+      # uses: brandedoutcast/publish-nuget@c12b8546b67672ee38ac87bea491ac94a587f7cc
+      uses: Rebel028/publish-nuget@v2.8.0
+      with:
+        # Filepath of the project to be packaged, relative to root of repository
+        PROJECT_FILE_PATH: DevKen.YoloPredictor.OpenCvBridge/DevKen.YoloPredictor.OpenCvBridge.csproj
+        # NuGet package id, used for version detection & defaults to project name
+        PACKAGE_NAME: DevKen.YoloPredictor.OpenCvBridge
+        # API key to authenticate with NuGet server
+        NUGET_KEY: ${{secrets.NUGET_API_KEY}}

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 This project provide following packages:  
 DevKen.YoloPredictor: [![NuGet version (DevKen.YoloPredictor)](https://img.shields.io/nuget/v/DevKen.YoloPredictor.svg?style=flat)](https://www.nuget.org/packages/DevKen.YoloPredictor/)  
 DevKen.YoloPredictor.Yolov5: [![NuGet version (DevKen.YoloPredictor.Yolov5)](https://img.shields.io/nuget/v/DevKen.YoloPredictor.Yolov5.svg?style=flat)](https://www.nuget.org/packages/DevKen.YoloPredictor.Yolov5/)  
+DevKen.YoloPredictor.OpenCvBridge: [![NuGet version (DevKen.YoloPredictor.OpenCvBridge)](https://img.shields.io/nuget/v/DevKen.YoloPredictor.OpenCvBridge.svg?style=flat)](https://www.nuget.org/packages/DevKen.YoloPredictor.OpenCvBridge/)  
   
 ------  
 ## What is this?  

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Post issues if any problems are found.
 //Create a predictor by providing modulepath and a backend.
 //Install corresponding OnnxRuntime nuget package.
 //For example, you need Microsoft.ML.OnnxRuntime.Gpu for CUDA.
-IYoloPredictor predictor = new YoloPredictorV5(modulepath, backend:YoloPredictorV5.Backend.CUDA);
+YoloPredictor predictor = new YoloPredictorV5(modulepath, backend:YoloPredictorV5.Backend.CUDA);
 
 //Predict on a Bitmap, then apply NMS and Confidence filter.
 var detresult = predictor.Predict((Bitmap)Bitmap.FromFile(picture)).NMSFilter().ConfidenceFilter();
@@ -25,8 +25,12 @@ var detresult = predictor.Predict((Bitmap)Bitmap.FromFile(picture)).NMSFilter().
 ### Predict on Mat  
 Opencv read camera and run prediction.
 ```  
+//Create a predictor by providing modulepath and a backend.
+YoloPredictor predictor = new YoloPredictorV5(modulepath, backend:YoloPredictorV5.Backend.CUDA, input_width: 640, input_height: 640);
+
 //Open video device
 VideoCapture vc = new VideoCapture(0);
+
 while (true)
 {
   //If frame presents

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ This project is designed to make YOLO intergration with .NET fast, easy and conv
 ## Use in critical projects?  
 DO NOT do that. This project is still under development and comes with NO guarantee.  
 Post issues if any problems are found.
-## Usage example
+## Usage example  
+### Predict on Bitmap  
 ```  
 //Create a predictor by providing modulepath and a backend.
 //Install corresponding OnnxRuntime nuget package.
@@ -20,4 +21,20 @@ IYoloPredictor predictor = new YoloPredictorV5(modulepath, backend:YoloPredictor
 
 //Predict on a Bitmap, then apply NMS and Confidence filter.
 var detresult = predictor.Predict((Bitmap)Bitmap.FromFile(picture)).NMSFilter().ConfidenceFilter();
+```  
+### Predict on Mat  
+Opencv read camera and run prediction.
+```  
+//Open video device
+VideoCapture vc = new VideoCapture(0);
+while (true)
+{
+  //If frame presents
+  if (vc.Read(image))
+  {
+    //Run detector on that frame, then apply NMSFilter and ConfidenceFilter.
+    var detresult = predictor.Predict(image).NMSFilter().ConfidenceFilter();
+    //** Do something with detresult here **
+  }
+}
 ```


### PR DESCRIPTION
**This patch drop some forward compability**  

- Removed IYoloPredictor. Use abstruct class YoloPredictor instead. 
+ Add support to `Predict` or `PredictAsync` on OpenCvSharp.Mat images.